### PR TITLE
Replacing dependency 'coloured' by 'colorize'

### DIFF
--- a/lib/seed_helper.rb
+++ b/lib/seed_helper.rb
@@ -1,4 +1,4 @@
-require 'colored'
+require 'colorize'
 require 'seed_helper/version'
 require 'seed_helper/output_formatter'
 require 'seed_helper/rake_helper'

--- a/lib/seed_helper/version.rb
+++ b/lib/seed_helper/version.rb
@@ -1,3 +1,3 @@
 class SeedHelper
-  VERSION = "1.4.2"
+  VERSION = "1.5.0"
 end

--- a/seed_helper.gemspec
+++ b/seed_helper.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'colored', '1.2'
+  s.add_dependency 'colorize', '~> 0.7.5'
   s.add_dependency 'rake', '>= 10.0.0'
 end

--- a/spec/lib/seed_formatter_spec.rb
+++ b/spec/lib/seed_formatter_spec.rb
@@ -24,14 +24,14 @@ describe SeedHelper do
     context 'options[:color] is provided' do
       let(:options) { {:color => :blue} }
       it "prints the message with the provided color" do
-        expect($stdout).to receive(:puts).with("\e[34mmessage\e[0m")
+        expect($stdout).to receive(:puts).with("\e[0;34;49mmessage\e[0m")
         subject
       end
     end
     context 'options[:color] is not provided' do
       let(:options) { {:color => nil} }
       it "prints the message in white by default" do
-        expect($stdout).to receive(:puts).with("\e[37mmessage\e[0m")
+        expect($stdout).to receive(:puts).with("\e[0;37;49mmessage\e[0m")
         subject
       end
     end


### PR DESCRIPTION
This Pull Request contains general dependencies updated:

* gem [colored](https://github.com/defunkt/colored) is no longer been maintained, using [colorize](https://github.com/fazibear/colorize);

I've got `colorize` in my personal project, use it to output better and beautiful log messages, but apparently, `colored` doesn't play nice when `colorize` is installed. That was my motivation to update all dependencies of seed_formatter.

All tests pass... :)